### PR TITLE
Branch moonmertens v1.1taska2a3a4

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 [![CI Status](https://github.com/AY2526S2-CS2103T-T13-1/tp/workflows/Java%20CI/badge.svg)](https://github.com/AY2526S2-CS2103T-T13-1/tp)
-[![codecov](https://codecov.io/gh/AY2526S2-CS2103T-T13-1/tp/graph/badge.svg?token=69QVHSVU3C)](https://codecov.io/gh/AY2526S2-CS2103T-T13-1/tp)
+[![codecov](https://codecov.io/gh/AY2526S2-CS2103T-T13-1/team-repo/graph/badge.svg?token=69QVHSVU3C)](https://codecov.io/gh/AY2526S2-CS2103T-T13-1/team-repo)
 
 ![Ui](docs/images/Ui.png)
 
@@ -8,3 +8,4 @@
 
 * For the detailed documentation of this project, please see the **[HRmanager Product Website](https://ay2526s2-cs2103t-t13-1.github.io/tp)**.
 * This project is based on the AddressBook-Level3 project created by the [SE-EDU initiative](https://se-education.org).
+


### PR DESCRIPTION
Update README.md to reflect current HRmanager product.

Currently, the codecov link in README.md points to https://codecov.io/gh/AY2526S2-CS2103T-T13-1/**team-repo**, and not https://codecov.io/gh/AY2526S2-CS2103T-T13-1/**tp**.

Should be edited if/when we change project name on codecov.

Resolves #30 
Resolves #32 
Resolves #33 