### PR TITLE
Lower the chain deletion limit

### DIFF
--- a/src/main/java/seedu/address/logic/commands/DeleteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteCommand.java
@@ -22,7 +22,7 @@ public class DeleteCommand extends Command implements ConfirmableCommand {
 
     public static final String COMMAND_WORD = "delete";
     public static final String COMMAND_ALIAS = "del";
-    public static final int MAX_INDEX_COUNT = 100;
+    public static final int MAX_INDEX_COUNT = 10;
     public static final String MESSAGE_DELETE_PERSON_SUCCESS = "Deleted employee(s): %1$s";
     public static final String ACTION_SUMMARY_FORMAT = "Delete %1$d employee(s).";
     public static final String IMPACT_SUMMARY = "The selected employee record(s) will be permanently removed.";


### PR DESCRIPTION
Fixes #267 

- Lower the chain deletion limit to 10 indices to prevent mistakes that may occur when too many indices are deleted at once.