### PR TITLE
Fix delete bugs from pe

### DIFF
--- a/src/main/java/seedu/address/logic/Messages.java
+++ b/src/main/java/seedu/address/logic/Messages.java
@@ -24,7 +24,7 @@ public class Messages {
     public static final String MESSAGE_SEARCH_KEYWORD_NOT_ALPHANUMERIC = "Keyword contains"
             + " non-alphanumeric characters.\n%1$s";
     public static final String MESSAGE_INVALID_COMMAND_FORMAT = "Invalid command format! \n%1$s";
-    public static final String MESSAGE_INVALID_PERSON_DISPLAYED_INDEX = "The person index provided is invalid.";
+        public static final String MESSAGE_INVALID_PERSON_DISPLAYED_INDEX = "The employee index provided is invalid.";
     public static final String MESSAGE_PERSONS_LISTED_OVERVIEW = "%1$d persons listed!";
     public static final String MESSAGE_INVALID_CONFIRMATION_INPUT =
             "Invalid confirmation input.\n"

--- a/src/main/java/seedu/address/logic/Messages.java
+++ b/src/main/java/seedu/address/logic/Messages.java
@@ -24,7 +24,7 @@ public class Messages {
     public static final String MESSAGE_SEARCH_KEYWORD_NOT_ALPHANUMERIC = "Keyword contains"
             + " non-alphanumeric characters.\n%1$s";
     public static final String MESSAGE_INVALID_COMMAND_FORMAT = "Invalid command format! \n%1$s";
-        public static final String MESSAGE_INVALID_PERSON_DISPLAYED_INDEX = "The employee index provided is invalid.";
+    public static final String MESSAGE_INVALID_PERSON_DISPLAYED_INDEX = "The employee index provided is invalid.";
     public static final String MESSAGE_PERSONS_LISTED_OVERVIEW = "%1$d persons listed!";
     public static final String MESSAGE_INVALID_CONFIRMATION_INPUT =
             "Invalid confirmation input.\n"

--- a/src/main/java/seedu/address/logic/commands/DeleteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteCommand.java
@@ -49,9 +49,10 @@ public class DeleteCommand extends Command implements ConfirmableCommand {
     public DeleteCommand(List<Index> targetIndexes) {
         requireNonNull(targetIndexes);
         targetIndexes.forEach(java.util.Objects::requireNonNull);
-        assert !targetIndexes.isEmpty() : "DeleteCommand requires at least one target index";
-        assert targetIndexes.size() <= MAX_INDEX_COUNT : "DeleteCommand received too many indexes";
-
+        if (targetIndexes.isEmpty()) {
+            throw new IllegalArgumentException("DeleteCommand requires at least one target index");
+        }
+        // Defensive: parser should already enforce unique count, but do not assert here
         this.targetIndexes = targetIndexes;
         logger.fine("DeleteCommand created with " + targetIndexes.size() + " requested index(es)");
     }

--- a/src/main/java/seedu/address/logic/parser/DeleteCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/DeleteCommandParser.java
@@ -29,11 +29,6 @@ public class DeleteCommandParser implements Parser<DeleteCommand> {
         }
 
         String[] tokens = trimmedArgs.split("\\s+");
-
-        if (tokens.length > DeleteCommand.MAX_INDEX_COUNT) {
-            throw new ParseException("Too many indexes specified.");
-        }
-
         List<Index> indexes = new ArrayList<>();
 
         try {
@@ -41,9 +36,21 @@ public class DeleteCommandParser implements Parser<DeleteCommand> {
                 indexes.add(ParserUtil.parseIndex(token));
             }
         } catch (ParseException pe) {
-            throw new ParseException(
-                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteCommand.MESSAGE_USAGE), pe);
+            // Propagate specific index error message if it's an invalid index
+            if (pe.getMessage().equals(seedu.address.logic.Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX)) {
+                throw pe;
+            } else {
+                throw new ParseException(
+                        String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteCommand.MESSAGE_USAGE), pe);
+            }
         }
+
+        // Deduplicate before checking max index count
+        long uniqueCount = indexes.stream().distinct().count();
+        if (uniqueCount > DeleteCommand.MAX_INDEX_COUNT) {
+            throw new ParseException("Too many indexes specified.");
+        }
+
         return new DeleteCommand(indexes);
     }
 }

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -7,7 +7,6 @@ import java.util.HashSet;
 import java.util.Set;
 
 import seedu.address.commons.core.index.Index;
-import seedu.address.commons.util.StringUtil;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.person.Department;
 import seedu.address.model.person.Email;
@@ -32,11 +31,15 @@ public class ParserUtil {
     public static Index parseIndex(String oneBasedIndex) throws ParseException {
         String trimmedIndex = oneBasedIndex.trim();
 
-        if (!StringUtil.isNonZeroUnsignedInteger(trimmedIndex)) {
-            throw new ParseException(MESSAGE_INVALID_INDEX);
+        try {
+            int value = Integer.parseInt(trimmedIndex);
+            if (value <= 0) {
+                throw new ParseException(seedu.address.logic.Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
+            }
+            return Index.fromOneBased(value);
+        } catch (NumberFormatException e) {
+            throw new ParseException(seedu.address.logic.Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
         }
-
-        return Index.fromOneBased(Integer.parseInt(trimmedIndex));
     }
 
     /**

--- a/src/test/java/seedu/address/logic/parser/DeleteCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/DeleteCommandParserTest.java
@@ -42,12 +42,12 @@ public class DeleteCommandParserTest {
 
     @Test
     public void parse_invalidArgs_throwsParseException() {
-        assertParseFailure(parser, "a", String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteCommand.MESSAGE_USAGE));
+        assertParseFailure(parser, "a", seedu.address.logic.Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
     }
 
     @Test
     public void parse_invalidIndexZero_throwsParseException() {
-        assertParseFailure(parser, "0", String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteCommand.MESSAGE_USAGE));
+        assertParseFailure(parser, "0", seedu.address.logic.Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
+++ b/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
@@ -2,7 +2,6 @@ package seedu.address.logic.parser;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static seedu.address.logic.parser.ParserUtil.MESSAGE_INVALID_INDEX;
 import static seedu.address.testutil.Assert.assertThrows;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
 

--- a/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
+++ b/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
@@ -55,7 +55,7 @@ public class ParserUtilTest {
 
     @Test
     public void parseIndex_outOfRangeInput_throwsParseException() {
-        assertThrows(ParseException.class, MESSAGE_INVALID_INDEX, ()
+        assertThrows(ParseException.class, seedu.address.logic.Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX, ()
             -> ParserUtil.parseIndex(Long.toString(Integer.MAX_VALUE + 1)));
     }
 


### PR DESCRIPTION
Fixes #365, 
where del 0 and the other large numbers are handled correctly.

Fixes #380,
where the duplicate indexes are made unique first before checking for validity. Order of operations.

Fixes #363 ,
where the error message now prints "employee" instead of "person"